### PR TITLE
Parse positive string numbers with plus sign into real numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,18 @@
 A very simple module that takes a JavaScript object and returns a new object with *string representations of booleans, nulls and numbers* converted to their proper types.
 
 So:
- * `"true"` and `"false"` becomes `true` and `false`
+ * `"true"` and `"false"` become `true` and `false`
+ * `"-1"` and `"-3.147"` become `-1` and `-3.147`
  * `"1"` and `"3.147"` become `1` and `3.147`
+ * `"+1"` and `"+3.147"` become `1` and `3.147`
  * `"192.168.1.1"` is left alone even though it "looks" like a number
  * `"null"` becomes `null`
 
 It works recursively, so nested structures are no problem.
 
-Array-like strings (currently, only comma-separated values are intepreted like this), are converted too:
+Array-like strings (currently, only comma-separated values are interpreted like this), are converted too:
 * `"test,one,two,three"` becomes `["test","one","two","three"]` (an array of strings)
-* `"0,1,2,3"` becomes `[0,1,2,3]` (an array of numbers) 
+* `"-1,0,1,+2,3"` becomes `[-1,0,1,2,3]` (an array of numbers) 
 
 Single-element arrays need you to provide a trailing comma to cue the parser appropriately:
 * `"1.1,"` becomes `[1.1]` (single-element array of numbers)

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,11 +29,8 @@ const convert = (value: string | any[]): any => {
       return undefined;
     default:
       // other cases
-      if (
-        !isNaN(parseFloat(value as string)) &&
-        value === parseFloat(value as string).toString()
-      ) {
-        return parseFloat(value);
+      if (isNumber(value)) {
+        return parseFloat(value as string);
       } else {
 
         if (isArrayLikeString(value) === true) {
@@ -47,6 +44,11 @@ const convert = (value: string | any[]): any => {
   }
 
   return result;
+};
+
+const isNumber = (value: any = ''): boolean => {
+  const val = '' + value;
+  return !isNaN(parseFloat(val)) && val === ((val.startsWith('+') ? '+' : '') + parseFloat(val).toString());
 };
 
 const convertArray = (a: any[]): any[] => a.map(el => convert(el));

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ const parseKeys = <T>(obj: object): T =>
   }, {}) as T;
 
 const convert = (value: string | any[]): any => {
-  let result: any = value;
 
   if (typeof value === "object" && value !== null) {
     if (Array.isArray(value)) {
@@ -42,8 +41,6 @@ const convert = (value: string | any[]): any => {
 
       }
   }
-
-  return result;
 };
 
 const isNumber = (value: any = ''): boolean => {
@@ -56,11 +53,7 @@ const convertArray = (a: any[]): any[] => a.map(el => convert(el));
 const isArrayLikeString = (s: any): boolean => {
   if (typeof s === "string") {
     const commaSeparated = s.split(",");
-    if (commaSeparated.length > 1) {
-      return true;
-    } else {
-      return false;
-    }
+    return commaSeparated.length > 1;
   } else {
     return false;
   } 


### PR DESCRIPTION
####What does it fix/implement? 

1) a fix for the method that parses numbers declared as strings. Currently, it does ignore numbers with `+` sign in strings leaving them untouched.
2) removes an unused variable.
3) simplifies an `if` statement
4) adds more tests to check that numbers declared with `+` sign are correctly tranformed into real numbers
5) updates the readme file

